### PR TITLE
Add GitHub Pages deployment with static site generation

### DIFF
--- a/.github/workflows/deploy-ghpages.yml
+++ b/.github/workflows/deploy-ghpages.yml
@@ -1,0 +1,30 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18'
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Build static site
+      run: npm run build:static
+
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+dist/

--- a/build-static.js
+++ b/build-static.js
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+
+/**
+ * Static site generator for WICYS @ OSU
+ * Generates static HTML files from Express templates for GitHub Pages deployment
+ * Original server.js remains unchanged for future NUC deployment
+ */
+
+const fs = require('fs');
+const path = require('path');
+const Handlebars = require('handlebars');
+const loadPosts = require('./loadPosts');
+
+// Register the same helper as in server.js
+Handlebars.registerHelper('encodeContent', function(content) {
+    if (!content) return '';
+    return content
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#x27;')
+        .replace(/\//g, '&#x2F;');
+});
+
+// Register partials
+const partialsDir = path.join(__dirname, 'views', 'partials');
+fs.readdirSync(partialsDir).forEach(file => {
+    const partialName = path.parse(file).name;
+    const partialPath = path.join(partialsDir, file);
+    const partialContent = fs.readFileSync(partialPath, 'utf-8');
+    Handlebars.registerPartial(partialName, partialContent);
+});
+
+// Load layout
+const layoutPath = path.join(__dirname, 'views', 'layouts', 'main.handlebars');
+const layout = fs.readFileSync(layoutPath, 'utf-8');
+
+// Load blog posts and images
+const blogData = loadPosts();
+const slidesData = require('./images.json');
+
+// Create output directory
+const outputDir = path.join(__dirname, 'dist');
+if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+}
+
+/**
+ * Compile and write a page
+ */
+function compilePage(viewName, context) {
+    const viewPath = path.join(__dirname, 'views', `${viewName}.handlebars`);
+    const viewContent = fs.readFileSync(viewPath, 'utf-8');
+
+    // Compile view
+    const viewTemplate = Handlebars.compile(viewContent);
+    const bodyHtml = viewTemplate(context);
+
+    // Inject into layout
+    const layoutTemplate = Handlebars.compile(layout);
+    const fullHtml = layoutTemplate({ body: bodyHtml });
+
+    return fullHtml;
+}
+
+/**
+ * Write HTML file
+ */
+function writePage(filePath, html) {
+    const dir = path.dirname(filePath);
+    if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+    }
+    fs.writeFileSync(filePath, html);
+    console.log(`✓ Generated: ${path.relative(outputDir, filePath)}`);
+}
+
+console.log('Building static site...\n');
+
+// Home page
+const homeContext = {
+    firstPost: blogData[0] ? blogData[0].desc : '',
+    slides: slidesData
+};
+writePage(path.join(outputDir, 'index.html'), compilePage('homePage', homeContext));
+
+// Blog page
+const blogContext = { blogData };
+writePage(path.join(outputDir, 'blog', 'index.html'), compilePage('blogPage', blogContext));
+
+// Resources page
+writePage(path.join(outputDir, 'resources', 'index.html'), compilePage('resourcesPage', {}));
+
+// Events page
+const options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
+const today = new Date().toLocaleDateString('en-US', options);
+const eventsContext = { today };
+writePage(path.join(outputDir, 'events', 'index.html'), compilePage('eventsPage', eventsContext));
+
+// Contact page
+writePage(path.join(outputDir, 'contact', 'index.html'), compilePage('contactPage', {}));
+
+// Sponsor page (if needed)
+writePage(path.join(outputDir, 'sponsor', 'index.html'), compilePage('sponsorPage', {}));
+
+// 404 page
+writePage(path.join(outputDir, '404.html'), compilePage('404Page', {}));
+
+// Copy static files
+const staticDir = path.join(__dirname, 'static');
+const distStaticDir = path.join(outputDir, 'static');
+
+function copyDir(src, dest) {
+    if (!fs.existsSync(dest)) {
+        fs.mkdirSync(dest, { recursive: true });
+    }
+    fs.readdirSync(src).forEach(file => {
+        const srcPath = path.join(src, file);
+        const destPath = path.join(dest, file);
+        if (fs.statSync(srcPath).isDirectory()) {
+            copyDir(srcPath, destPath);
+        } else {
+            fs.copyFileSync(srcPath, destPath);
+        }
+    });
+}
+
+copyDir(staticDir, distStaticDir);
+
+const imagesDir = path.join(__dirname, 'images');
+if (fs.existsSync(imagesDir)) {
+    copyDir(imagesDir, path.join(outputDir, 'images'));
+}
+
+console.log('\n✅ Static site built successfully!');
+console.log(`📁 Output directory: ./dist`);
+console.log('\nTo deploy to GitHub Pages:');
+console.log('  1. Push the dist folder to the gh-pages branch');
+console.log('  2. Enable GitHub Pages in repository settings');

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node server.js",
     "build": "node node_modules/handlebars/bin/handlebars views/partials/slideshow.handlebars -f static/slideshowTemplate.js && node node_modules/handlebars/bin/handlebars views/partials/singlePost.handlebars -f static/singlePostTemplate.js",
+    "build:static": "node build-static.js",
     "prestart": "npm run build",
     "dev": "nodemon server.js"
   },


### PR DESCRIPTION
## Summary
- Added static site generator (`build-static.js`) that converts Express templates to static HTML without modifying the existing server
- Created GitHub Actions workflow to automatically deploy to GitHub Pages on push to main
- This is a **temporary solution** for immediate deployment — the Express server.js remains unchanged for future NUC deployment

## Key Features
- ✅ One-time npm setup required (dependencies already installed)
- ✅ Reversible: Can switch back to server at any time
- ✅ Automated: GitHub Actions handles deployment
- ✅ All existing server code preserved

## How to Use
Locally: `npm run build:static` generates the static site in `./dist/`

On push: GitHub Actions automatically builds and deploys to GitHub Pages

## Testing
- [x] Build script generates all pages
- [x] Static files copied to dist/
- [x] Ready for GitHub Pages

🤖 Generated with Claude Code